### PR TITLE
Don't create scrollview when disabled

### DIFF
--- a/src/load.py
+++ b/src/load.py
@@ -699,8 +699,12 @@ def update_display() -> None:
         this.total_label.grid_remove()
         return
     else:
-        this.scroll_canvas.grid()
-        this.scrollbar.grid()
+        if this.show_details.get():
+            this.scroll_canvas.grid()
+            this.scrollbar.grid()
+        else:
+            this.scroll_canvas.grid_remove()
+            this.scrollbar.grid_remove()
         this.total_label.grid()
 
     valuable_body_names = [


### PR DESCRIPTION
There's an annoying flicker on update if the scrollview is disabled.

I believe this change prevents the canvas and scrollbar from being created and then immediately destroyed?