### PR TITLE
fix: version check exception fix

### DIFF
--- a/src/load.py
+++ b/src/load.py
@@ -94,7 +94,7 @@ def version_check() -> str:
         data = req.json()
         if req.status_code != requests.codes.ok:
             raise requests.RequestException
-    except (requests.RequestException, ValueError):
+    except (requests.RequestException, requests.JSONDecodeError):
         print_exc()
         return ''
 

--- a/src/load.py
+++ b/src/load.py
@@ -94,7 +94,7 @@ def version_check() -> str:
         data = req.json()
         if req.status_code != requests.codes.ok:
             raise requests.RequestException
-    except requests.RequestException | requests.JSONDecodeError:
+    except (requests.RequestException, ValueError):
         print_exc()
         return ''
 


### PR DESCRIPTION
```console
ERROR - 20218:140206965758848:20218 plug.Plugin.get_app:155: Failed for Plugin "Pioneer"
Traceback (most recent call last):
  File "~/EDMarketConnector/plugins/EDMC-Pioneer/load.py", line 93, in version_check
    raise requests.RequestException
requests.exceptions.RequestException

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/edmarketconnector/plug.py", line 141, in get_app
    appitem = plugin_app(parent)
  File "~/EDMarketConnector/plugins/EDMC-Pioneer/load.py", line 159, in plugin_app
    update = version_check()
  File "~/EDMarketConnector/plugins/EDMC-Pioneer/load.py", line 94, in version_check
    except requests.RequestException | requests.JSONDecodeError:
        print_exc()
        return ''
TypeError: catching classes that do not inherit from BaseException is not allowed
```

- This caused the plugin to crash and fail to load when a GitHub error occurred (such as a 403).